### PR TITLE
Remove REQUIRED from find_dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14...3.25)
 
 project(umappp
-    VERSION 3.3.1
+    VERSION 3.3.2
     DESCRIPTION "A C++ implementation of the UMAP algorithm"
     LANGUAGES CXX)
 

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,11 +1,11 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(ltla_aarand 1.1.0 CONFIG REQUIRED)
-find_dependency(ltla_sanisizer 0.2.0 CONFIG REQUIRED)
-find_dependency(ltla_subpar 0.5.0 CONFIG REQUIRED)
-find_dependency(ltla_irlba 3.1.0 CONFIG REQUIRED)
-find_dependency(Eigen3 5.0.0 CONFIG REQUIRED)
-find_dependency(knncolle_knncolle 3.1.0 CONFIG REQUIRED)
+find_dependency(ltla_aarand 1.1.0 CONFIG)
+find_dependency(ltla_irlba 3.1.0 CONFIG)
+find_dependency(Eigen3 5.0.0 CONFIG)
+find_dependency(ltla_subpar 0.5.0 CONFIG)
+find_dependency(ltla_sanisizer 0.2.0 CONFIG)
+find_dependency(knncolle_knncolle 3.1.0 CONFIG)
 
 include("${CMAKE_CURRENT_LIST_DIR}/libscran_umapppTargets.cmake")


### PR DESCRIPTION
The purpose of find_dependency is to propagate REQUIRED-ness from the caller into dependencies, if required.

That is, find_package(libscran_umappp QUIET) should make the inner search for Eigen3 itself QUIET, but putting REQUIRED there breaks this.

Also fixed the order to exactly match the find_package block:

https://github.com/libscran/umappp/blob/8a6efdf0b5be73310fc079640127072b99332f75/CMakeLists.txt#L25-L30